### PR TITLE
Failing tests for query with postgis types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+spaces_around_operators = true
+max_line_length = 130
+
+[pom.xml]
+# Because of <project... line
+max_line_length = 999

--- a/src/test/java/org/example/domain/MyBean.java
+++ b/src/test/java/org/example/domain/MyBean.java
@@ -7,6 +7,7 @@ import org.postgis.MultiPolygon;
 import org.postgis.Point;
 import org.postgis.Polygon;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -27,6 +28,9 @@ public class MyBean extends BaseEntity {
   MultiPoint multiPoint;
 
   MultiPolygon mpoly;
+
+  @Column(columnDefinition = "geometry(Point, 4326)")
+  Point wgs84Point;
 
   public String getName() {
     return name;
@@ -82,5 +86,13 @@ public class MyBean extends BaseEntity {
 
   public void setMpoly(MultiPolygon mpoly) {
     this.mpoly = mpoly;
+  }
+
+  public Point getWgs84Point() {
+    return wgs84Point;
+  }
+
+  public void setWgs84Point(final Point wgs84Point) {
+    this.wgs84Point = wgs84Point;
   }
 }

--- a/src/test/java/org/example/domain/MyBean.java
+++ b/src/test/java/org/example/domain/MyBean.java
@@ -29,7 +29,7 @@ public class MyBean extends BaseEntity {
 
   MultiPolygon mpoly;
 
-  @Column(columnDefinition = "geometry(Point, 4326)")
+  @Column(columnDefinition = "geometry(Point, 4326)", unique = true)
   Point wgs84Point;
 
   public String getName() {

--- a/src/test/java/org/example/domain/OtherBeanGeoLatte.java
+++ b/src/test/java/org/example/domain/OtherBeanGeoLatte.java
@@ -1,6 +1,7 @@
 package org.example.domain;
 
 
+import org.geolatte.geom.G2D;
 import org.geolatte.geom.LineString;
 import org.geolatte.geom.MultiLineString;
 import org.geolatte.geom.MultiPoint;
@@ -8,6 +9,7 @@ import org.geolatte.geom.MultiPolygon;
 import org.geolatte.geom.Point;
 import org.geolatte.geom.Polygon;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -28,6 +30,9 @@ public class OtherBeanGeoLatte extends BaseEntity {
   MultiPoint multiPoint;
 
   MultiPolygon mpoly;
+
+  @Column(columnDefinition = "geometry(Point, 4326)")
+  Point<G2D> wgs84Point;
 
   public String getName() {
     return name;
@@ -83,5 +88,13 @@ public class OtherBeanGeoLatte extends BaseEntity {
 
   public void setMultiPoint(MultiPoint multiPoint) {
     this.multiPoint = multiPoint;
+  }
+
+  public Point<G2D> getWgs84Point() {
+    return wgs84Point;
+  }
+
+  public void setWgs84Point(final Point<G2D> wgs84Point) {
+    this.wgs84Point = wgs84Point;
   }
 }

--- a/src/test/java/org/example/domain/OtherBeanGeoLatte.java
+++ b/src/test/java/org/example/domain/OtherBeanGeoLatte.java
@@ -31,7 +31,7 @@ public class OtherBeanGeoLatte extends BaseEntity {
 
   MultiPolygon mpoly;
 
-  @Column(columnDefinition = "geometry(Point, 4326)")
+  @Column(columnDefinition = "geometry(Point, 4326)", unique = true)
   Point<G2D> wgs84Point;
 
   public String getName() {

--- a/src/test/java/org/example/domain/TestInsertQuery.java
+++ b/src/test/java/org/example/domain/TestInsertQuery.java
@@ -1,7 +1,6 @@
 package org.example.domain;
 
 import io.ebean.Ebean;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.postgis.LineString;
 import org.postgis.MultiLineString;
 import org.postgis.MultiPoint;
@@ -18,8 +17,7 @@ public class TestInsertQuery {
   /**
    * Not automated this test yet.
    */
-  @Ignore
-  @Test
+  @Test(enabled = false)
   public void insert() throws SQLException {
 
 

--- a/src/test/java/org/example/domain/TestOtherInsertQuery.java
+++ b/src/test/java/org/example/domain/TestOtherInsertQuery.java
@@ -1,7 +1,6 @@
 package org.example.domain;
 
 import io.ebean.Ebean;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.geolatte.geom.Point;
 import org.geolatte.geom.Polygon;
 import org.geolatte.geom.codec.Wkt;
@@ -19,8 +18,7 @@ public class TestOtherInsertQuery {
   /**
    * Not automated this test yet.
    */
-  @Ignore
-  @Test
+  @Test(enabled = false)
   public void insert() throws SQLException {
 
 

--- a/src/test/java/org/example/domain/TestQuery.java
+++ b/src/test/java/org/example/domain/TestQuery.java
@@ -1,86 +1,250 @@
 package org.example.domain;
 
+import static org.geolatte.geom.codec.Wkt.toWkt;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
 import org.geolatte.geom.G2D;
+import org.geolatte.geom.LineString;
+import org.geolatte.geom.MultiLineString;
+import org.geolatte.geom.MultiPoint;
+import org.geolatte.geom.MultiPolygon;
 import org.geolatte.geom.Point;
+import org.geolatte.geom.Polygon;
+import org.geolatte.geom.PositionSequenceBuilders;
 import org.geolatte.geom.crs.CoordinateReferenceSystems;
-import org.junit.Ignore;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import io.ebean.DB;
 
 public class TestQuery {
-  @Ignore
+
+  private final Point<G2D> wgs84Point = new Point<>(
+    new G2D(174.76345825195312, -36.85315704345703),
+    CoordinateReferenceSystems.WGS84
+  );
+
+  private final Point<G2D> geolatteClosePoint = new Point<>(
+    new G2D(174.75345825195312, -36.85315704345703),
+    CoordinateReferenceSystems.WGS84
+  );
+
+  private final Polygon<G2D> enclosingPolygon = new Polygon<>(
+    PositionSequenceBuilders
+      .variableSized(G2D.class)
+      .add(new G2D(174.70345825195312, -36.85315704345703))
+      .add(new G2D(174.79345825195312, -36.80315704345703))
+      .add(new G2D(174.79345825195312, -36.89315704345703))
+      .add(new G2D(174.70345825195312, -36.85315704345703))
+      .toPositionSequence(),
+    CoordinateReferenceSystems.WGS84
+  );
+
+  private final LineString<G2D> lineString = new LineString<>(
+    PositionSequenceBuilders
+      .variableSized(G2D.class)
+      .add(new G2D(174.70345825195312, -36.85315704345703))
+      .add(wgs84Point.getPosition())
+      .add(new G2D(174.79345825195312, -36.89315704345703))
+      .toPositionSequence(),
+    CoordinateReferenceSystems.WGS84
+  );
+
+  @SuppressWarnings("unchecked")
+  private final MultiPoint<G2D> multiPoint = new MultiPoint<>(
+    new Point<>(new G2D(174.70345825195312, -36.85315704345703), CoordinateReferenceSystems.WGS84),
+    wgs84Point,
+    new Point<>(new G2D(174.79345825195312, -36.89315704345703), CoordinateReferenceSystems.WGS84)
+  );
+
+  @SuppressWarnings("unchecked")
+  private final MultiPolygon<G2D> multiPolygon = new MultiPolygon<>(
+    enclosingPolygon,
+    new Polygon<>(
+      PositionSequenceBuilders
+        .variableSized(G2D.class)
+        .add(new G2D(0, 51.47))
+        .add(new G2D(0.01, 51.49))
+        .add(new G2D(-0.01, 51.49))
+        .add(new G2D(0, 51.47))
+        .toPositionSequence(),
+      CoordinateReferenceSystems.WGS84
+    )
+  );
+
+  @SuppressWarnings("unchecked")
+  private final MultiLineString<G2D> multiLineString = new MultiLineString<>(
+    lineString,
+    new LineString<>(
+      PositionSequenceBuilders
+        .variableSized(G2D.class)
+        .add(new G2D(0, 51.47))
+        .add(new G2D(0.01, 51.49))
+        .add(new G2D(-0.01, 51.49))
+        .add(new G2D(-0.00, 51.47))
+        .toPositionSequence(),
+      CoordinateReferenceSystems.WGS84
+    )
+  );
+
+  @BeforeTest
+  public void setupObjects() {
+    OtherBeanGeoLatte geoLatte = new OtherBeanGeoLatte();
+    geoLatte.setWgs84Point(wgs84Point);
+    DB.save(geoLatte);
+  }
+
+  @AfterTest
+  public void cleanup() {
+    DB
+      .find(MyBean.class)
+      .delete();
+    DB.find(OtherBeanGeoLatte.class)
+      .delete();
+  }
+
   @Test
   public void testGeoQueryGeoLatte() {
-    OtherBeanGeoLatte mb = new OtherBeanGeoLatte();
-    mb.setWgs84Point(
-      new Point<>(
-        new G2D(174.76345825195312, -36.85315704345703),
-        CoordinateReferenceSystems.WGS84
-      )
-    );
-    DB.save(mb);
-
     // Approx 1100 meters away
     // 0.009999999999990905 degrees away
-    Point<G2D> closePoint = new Point<>(
-      new G2D(174.75345825195312, -36.85315704345703),
-      CoordinateReferenceSystems.WGS84
-    );
+
+//    System.err.println(
+//      DB
+//        .sqlQuery("SELECT st_distance(wgs84_point, ?), * FROM mybean").setParameter(toWkt(geolatteClosePoint))
+//        .findOne()
+//    );
 
     assertNotNull(
       DB
-      .find(OtherBeanGeoLatte.class)
-      .where()
-//      .raw("st_distance(wgs84Point, ?) < 0.011", Wkt.newEncoder().encode(closePoint))
-          .raw("st_distance(wgs84Point, ?) < 0.011 ", closePoint)
-      .findOne()
+        .find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("st_distance(wgs84Point, ?) < 0.011", toWkt(geolatteClosePoint))
+//        .raw("st_distance(wgs84Point, ?) < 0.011 ", geolatteClosePoint)
+        .findOne()
     );
 
     assertNull(
       DB
         .find(OtherBeanGeoLatte.class)
         .where()
-//        .raw("st_distance(wgs84Point, ?) < 0.009", Wkt.newEncoder().encode(closePoint))
-        .raw("st_distance(wgs84Point, ?) < 0.009", closePoint)
+        .raw("st_distance(wgs84Point, ?) < 0.009", toWkt(geolatteClosePoint))
+//        .raw("st_distance(wgs84Point, ?) < 0.009", geolatteClosePoint)
+        .findOne()
+    );
+
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("ST_Within(wgs84Point, ST_GeomFromText(?))", toWkt(enclosingPolygon))
+//        .raw("ST_Within(wgs84Point, ?)", enclosingPolygon)
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("wgs84Point = ST_PointN(ST_GeomFromText(?), 2)", toWkt(lineString))
+//      .raw("wgs84Point = ST_PointN(?, 2)", lineString)
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("wgs84Point = ST_PointN(ST_LineFromMultiPoint(ST_GeomFromText(?)), 2)", toWkt(multiPoint))
+//      .raw("wgs84Point = ST_PointN(ST_LineFromMultiPoint(?), 2)", multiPoint)
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("ST_Within(wgs84Point, ST_GeomFromText(?))", toWkt(multiPolygon))
+//        .raw("ST_Within(wgs84Point, ?)", multiPolygon)
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("ST_Intersects(wgs84Point, ST_GeomFromText(?))", toWkt(multiLineString))
+//        .raw("ST_Intersects(wgs84Point, ?)", multiLineString)
         .findOne()
     );
   }
 
-  @Ignore
   @Test
-  public void testGeoQueryPostgis() {
-    MyBean mb = new MyBean();
-    final org.postgis.Point wgs84Point = new org.postgis.Point(174.76345825195312, -36.85315704345703);
-    wgs84Point.setSrid(4326);
-    mb.setWgs84Point(wgs84Point);
-    DB.save(mb);
-
-    org.postgis.Point closePoint = new org.postgis.Point(174.75345825195312, -36.85315704345703);
+  public void testGeoQueryPostgis() throws Exception {
 
     assertNotNull(
       DB
-      .find(MyBean.class)
-      .where()
-//      .raw("st_distance(wgs84Point, ?) < 0.011", toText(closePoint))
-      .raw("st_distance(wgs84Point, ?) < 0.011", closePoint)
-      .findOne()
+        .find(MyBean.class)
+        .where()
+        .raw("st_distance(wgs84Point, ?) < 0.011", toWkt(geolatteClosePoint))
+//        .raw("st_distance(wgs84Point, ?) < 0.011", new org.postgis.Point(toWkt(geolatteClosePoint)))
+        .findOne()
     );
 
     assertNull(
       DB
         .find(MyBean.class)
         .where()
-//        .raw("st_distance(wgs84Point, ?) < 0.009", toText(closePoint))
-        .raw("st_distance(wgs84Point, ?) < 0.009", closePoint)
+        .raw("st_distance(wgs84Point, ?) < 0.009", toWkt(geolatteClosePoint))
+//        .raw("st_distance(wgs84Point, ?) < 0.009", postgisClosePoint)
         .findOne()
     );
-  }
 
-  public String toText(org.postgis.Point wgs84Point) {
-    return "SRID=4326;POINT(" + wgs84Point.getX() + " " + wgs84Point.getY() + ")";
+    assertNotNull(
+      DB
+        .find(MyBean.class)
+        .where()
+        .raw("ST_Within(wgs84Point, ST_GeomFromText(?))", toWkt(enclosingPolygon))
+//        .raw("ST_Within(wgs84Point, ?)", new org.postgis.Polygon(toWkt(enclosingPolygon)))
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(MyBean.class)
+        .where()
+        .raw("wgs84Point = ST_PointN(ST_GeomFromText(?), 2)", toWkt(lineString))
+//        .raw("wgs84Point = ST_PointN(?, 2)", new org.postgis.LineString(toWkt(lineString)))
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("wgs84Point = ST_PointN(ST_LineFromMultiPoint(ST_GeomFromText(?)), 2)", toWkt(multiPoint))
+//      .raw("wgs84Point = ST_PointN(ST_LineFromMultiPoint(?), 2)", new org.postgis.MultiPoint(toWkt(multiPoint)))
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("wgs84Point = ST_PointN(ST_LineFromMultiPoint(ST_GeomFromText(?)), 2)", toWkt(multiPoint))
+//      .raw("wgs84Point = ST_PointN(ST_LineFromMultiPoint(?), 2)", new org.postgis.MultiPoint(toWkt(multiPoint)))
+        .findOne()
+    );
+
+    assertNotNull(
+      DB
+        .find(MyBean.class)
+        .where()
+        .raw("ST_Within(wgs84Point, ST_GeomFromText(?))", toWkt(multiPolygon))
+//        .raw("ST_Within(wgs84Point, ?)", new org.postgis.Polygon(toWkt(multiPolygon)))
+        .findOne()
+    );
+
+    assertNotNull(
+      DB.find(OtherBeanGeoLatte.class)
+        .where()
+        .raw("ST_Intersects(wgs84Point, ST_GeomFromText(?))", toWkt(multiLineString))
+//        .raw("ST_Intersects(wgs84Point, ?)", new org.postgis.MultiLineString(toWkt(multiLineString)))
+        .findOne()
+    );
   }
 }

--- a/src/test/java/org/example/domain/TestQuery.java
+++ b/src/test/java/org/example/domain/TestQuery.java
@@ -1,0 +1,86 @@
+package org.example.domain;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.Point;
+import org.geolatte.geom.crs.CoordinateReferenceSystems;
+import org.junit.Ignore;
+import org.testng.annotations.Test;
+
+import io.ebean.DB;
+
+public class TestQuery {
+  @Ignore
+  @Test
+  public void testGeoQueryGeoLatte() {
+    OtherBeanGeoLatte mb = new OtherBeanGeoLatte();
+    mb.setWgs84Point(
+      new Point<>(
+        new G2D(174.76345825195312, -36.85315704345703),
+        CoordinateReferenceSystems.WGS84
+      )
+    );
+    DB.save(mb);
+
+    // Approx 1100 meters away
+    // 0.009999999999990905 degrees away
+    Point<G2D> closePoint = new Point<>(
+      new G2D(174.75345825195312, -36.85315704345703),
+      CoordinateReferenceSystems.WGS84
+    );
+
+    assertNotNull(
+      DB
+      .find(OtherBeanGeoLatte.class)
+      .where()
+//      .raw("st_distance(wgs84Point, ?) < 0.011", Wkt.newEncoder().encode(closePoint))
+          .raw("st_distance(wgs84Point, ?) < 0.011 ", closePoint)
+      .findOne()
+    );
+
+    assertNull(
+      DB
+        .find(OtherBeanGeoLatte.class)
+        .where()
+//        .raw("st_distance(wgs84Point, ?) < 0.009", Wkt.newEncoder().encode(closePoint))
+        .raw("st_distance(wgs84Point, ?) < 0.009", closePoint)
+        .findOne()
+    );
+  }
+
+  @Ignore
+  @Test
+  public void testGeoQueryPostgis() {
+    MyBean mb = new MyBean();
+    final org.postgis.Point wgs84Point = new org.postgis.Point(174.76345825195312, -36.85315704345703);
+    wgs84Point.setSrid(4326);
+    mb.setWgs84Point(wgs84Point);
+    DB.save(mb);
+
+    org.postgis.Point closePoint = new org.postgis.Point(174.75345825195312, -36.85315704345703);
+
+    assertNotNull(
+      DB
+      .find(MyBean.class)
+      .where()
+//      .raw("st_distance(wgs84Point, ?) < 0.011", toText(closePoint))
+      .raw("st_distance(wgs84Point, ?) < 0.011", closePoint)
+      .findOne()
+    );
+
+    assertNull(
+      DB
+        .find(MyBean.class)
+        .where()
+//        .raw("st_distance(wgs84Point, ?) < 0.009", toText(closePoint))
+        .raw("st_distance(wgs84Point, ?) < 0.009", closePoint)
+        .findOne()
+    );
+  }
+
+  public String toText(org.postgis.Point wgs84Point) {
+    return "SRID=4326;POINT(" + wgs84Point.getX() + " " + wgs84Point.getY() + ")";
+  }
+}


### PR DESCRIPTION
```
javax.persistence.PersistenceException: Error with property[0] dt[6000]data[POINT(174.75345825195313 -36.85315704345703)][org.postgis.Point]

	at io.ebeaninternal.server.persist.Binder.bindSimpleData(Binder.java:390)
	at io.ebeaninternal.server.persist.Binder.bindObject(Binder.java:289)
	at io.ebeaninternal.server.persist.Binder.bindObject(Binder.java:239)
	at io.ebeaninternal.server.expression.DefaultExpressionRequest.bind(DefaultExpressionRequest.java:71)
	at io.ebeaninternal.server.query.CQueryPredicates.bind(CQueryPredicates.java:168)
	at io.ebeaninternal.server.query.CQuery.prepareResultSet(CQuery.java:369)
	at io.ebeaninternal.server.query.CQuery.prepareBindExecuteQueryWithOption(CQuery.java:320)
	at io.ebeaninternal.server.query.CQuery.prepareBindExecuteQuery(CQuery.java:315)
	at io.ebeaninternal.server.query.CQueryEngine.findMany(CQueryEngine.java:371)
	at io.ebeaninternal.server.query.DefaultOrmQueryEngine.findMany(DefaultOrmQueryEngine.java:131)
	at io.ebeaninternal.server.core.OrmQueryRequest.findList(OrmQueryRequest.java:452)
	at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1528)
	at io.ebeaninternal.server.core.DefaultServer.findOne(DefaultServer.java:1202)
	at io.ebeaninternal.server.querydefn.DefaultOrmQuery.findOne(DefaultOrmQuery.java:1574)
	at io.ebeaninternal.server.expression.DefaultExpressionList.findOne(DefaultExpressionList.java:471)
	at org.example.domain.TestQuery.testGeoQueryPostgis(TestQuery.java:74)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:86)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:643)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:820)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1128)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at org.testng.TestRunner.privateRun(TestRunner.java:782)
	at org.testng.TestRunner.run(TestRunner.java:632)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:366)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:361)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:319)
	at org.testng.SuiteRunner.run(SuiteRunner.java:268)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1244)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1169)
	at org.testng.TestNG.run(TestNG.java:1064)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:109)
Caused by: java.sql.SQLException: Unhandled data type [6000] bind number[0]
	at io.ebeaninternal.server.persist.Binder.bindSimpleData(Binder.java:380)
	... 38 more
```